### PR TITLE
Add support for embedded bash script overlays in ELF binaries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,12 @@ upstream GNU tools. Intended for distroless containers and script shebangs.
 Always launches as bash, with all bundled tools available as pseudo-builtins.
 
 ## Project layout
-- `src/` - C source for entry point, applet table, and scanner
+- `src/` - C source for entry point, feature gates, and scanner
 - `src/applets.h` - X-macro applet registry (single source of truth)
-- `src/applets.c` - Applet dispatch table (consumes applets.h, handles filtering)
-- `src/applet_table.h` - Shared struct/API for applet lookup
+- `src/features.c` - Feature gates + applet dispatch (the lightweight recompile target)
+- `src/applet_table.h` - Shared struct/API for applet lookup + feature thunks
+- `src/overlay.c` - Embedded script overlay support (ELF parsing, UPX, gzip)
+- `src/overlay.h` - Overlay API (busyq_load_overlay)
 - `src/busyq_scan_main.c` - Scanner binary entry point + classifier
 - `src/busyq_scan_walk.c` - AST walker (compiled within bash port)
 - `src/busyq_scan.h` - Shared types for scanner components
@@ -43,9 +45,9 @@ cmake --preset no-ssl -DBUSYQ_APPLETS="cat;curl;jq;ls;mkdir;sort"
 cmake --build --preset no-ssl
 
 # 3b. Or link against the pre-built library (fast, no vcpkg needed)
-cc -DBUSYQ_CUSTOM_APPLETS -DAPPLET_cat=1 -DAPPLET_curl=1 -DAPPLET_jq=1 \
-   -DAPPLET_ls=1 -DAPPLET_mkdir=1 -DAPPLET_sort=1 \
-   -flto -static -Os src/applets.c -Isrc/ libbusyq.a -lm -ldl -lpthread -o busyq
+cc -DBUSYQ_CUSTOM_APPLETS -DBUSYQ_OVERLAY -DAPPLET_cat=1 -DAPPLET_curl=1 \
+   -DAPPLET_jq=1 -DAPPLET_ls=1 -DAPPLET_mkdir=1 -DAPPLET_sort=1 \
+   -flto -static -Os src/features.c -Isrc/ libbusyq.a -lm -ldl -lpthread -o busyq
 ```
 
 ### Build architecture (vcpkg overlay ports)
@@ -64,9 +66,11 @@ and build orchestration. The top-level CMakeLists.txt links everything together.
 - Bash command lookup patched in findcmd.c to check applet table before PATH
 - Entry point always calls bash_main(); bash's own sh/POSIX-mode logic preserved
 - Tool main() functions renamed via -Dmain=toolname_main at compile time
-- All tools registered in src/applets.h (X-macro) and dispatched via src/applets.c
+- All tools registered in src/applets.h (X-macro) and dispatched via src/features.c
 - Applet filtering at compile time: -DBUSYQ_CUSTOM_APPLETS + -DAPPLET_<name>=1
   allows LTO to strip unreferenced entry functions (no code generation needed)
+- Feature gates in src/features.c: compile-time defines (-DBUSYQ_OVERLAY, etc.)
+  control thunks that LTO uses to prune entire subsystems from the final binary
 - Coreutils uses per-command entry points (single_binary_main_*) instead of a
   shared dispatcher, enabling LTO to prune unused commands in custom builds
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ project(busyq C)
 #   1. Build libbusyq.a once (expensive: vcpkg ports + LTO compilation)
 #   2. Run:  busyq-scan myscript.sh --applets
 #   3. Compile: cc -DBUSYQ_CUSTOM_APPLETS -DAPPLET_curl=1 -DAPPLET_ls=1 \
-#               -flto -static -Os src/applets.c -Isrc/ libbusyq.a \
+#               -flto -static -Os src/features.c -Isrc/ libbusyq.a \
 #               -lm -ldl -lpthread -o busyq
 #      (Fast: no vcpkg rebuild, just compile one .c + final link w/ LTO)
 
@@ -154,21 +154,20 @@ if(BUSYQ_SSL)
     endif()
 endif()
 
-# Overlay: embedded script detection (uses zlib already linked via component libs)
-if(BUSYQ_OVERLAY)
-    target_sources(busyq_main PRIVATE src/overlay.c)
-    target_compile_definitions(busyq_main PRIVATE BUSYQ_OVERLAY)
-endif()
+# Overlay: always compiled into the library so it's available for custom builds.
+# Enabled/disabled via BUSYQ_OVERLAY define on features.c (not main.c), allowing
+# LTO to prune the overlay code when the feature gate returns NULL.
+target_sources(busyq_main PRIVATE src/overlay.c)
 
 # =====================================================================
 # libbusyq.a — merged archive of main.o + all component libraries
 #
-# Contains everything needed for a busyq binary EXCEPT the applet
-# dispatch table (applets.c).  Distributed as an LTO-enabled
-# artifact so users can link a custom applet table quickly:
+# Contains everything needed for a busyq binary EXCEPT the feature
+# gates and applet table (features.c).  Distributed as an LTO-enabled
+# artifact so users can link a custom features.c quickly:
 #
 #   cc -DBUSYQ_CUSTOM_APPLETS -DAPPLET_curl=1 -flto -static \
-#      src/applets.c -Isrc/ libbusyq.a -lm -ldl -lpthread -o busyq
+#      src/features.c -Isrc/ libbusyq.a -lm -ldl -lpthread -o busyq
 #
 # Uses an ar MRI script to merge all archives + object files into one.
 # =====================================================================
@@ -194,17 +193,17 @@ add_custom_command(
 add_custom_target(busyq-lib DEPENDS "${BUSYQ_LIB}")
 
 # =====================================================================
-# Applet table — full or filtered via preprocessor
+# Feature gates + applet table — the lightweight recompile target
 #
-# src/applets.c includes src/applets.h (X-macro registry).  Filtering
-# is done at compile time: -DBUSYQ_CUSTOM_APPLETS plus individual
-# -DAPPLET_<name>=1 flags select which applets to include.  No code
-# generation step is needed.
+# src/features.c is the only file recompiled during custom builds.
+# It controls applet selection (APPLET_<name> macros from applets.h)
+# and feature flags (BUSYQ_OVERLAY, etc.).  LTO prunes unreferenced
+# code from the pre-built libbusyq.a based on what features.c enables.
 #
 # When BUSYQ_APPLETS is set (semicolon-separated list), CMake converts
 # it to the appropriate compile definitions.
 # =====================================================================
-add_executable(busyq src/applets.c)
+add_executable(busyq src/features.c)
 
 target_include_directories(busyq PRIVATE
     src
@@ -214,6 +213,10 @@ target_include_directories(busyq PRIVATE
 
 if(BUSYQ_SSL)
     target_compile_definitions(busyq PRIVATE BUSYQ_SSL)
+endif()
+
+if(BUSYQ_OVERLAY)
+    target_compile_definitions(busyq PRIVATE BUSYQ_OVERLAY)
 endif()
 
 if(BUSYQ_APPLETS)
@@ -291,5 +294,5 @@ endif()
 
 # Install the library and headers for custom builds
 install(FILES "${BUSYQ_LIB}" DESTINATION lib OPTIONAL)
-install(FILES src/applet_table.h src/applets.h DESTINATION include/busyq)
-install(FILES src/applets.c DESTINATION share/busyq)
+install(FILES src/applet_table.h src/applets.h src/overlay.h DESTINATION include/busyq)
+install(FILES src/features.c DESTINATION share/busyq)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(CMAKE_C_STANDARD 11)
 
 # Options
 option(BUSYQ_SSL "Build with mbedTLS SSL support and embedded certificates" OFF)
+option(BUSYQ_OVERLAY "Enable detection of bash scripts appended as ELF overlay data" ON)
 set(BUSYQ_APPLETS "" CACHE STRING
     "Semicolon-separated applet names to include (empty string = all)")
 
@@ -151,6 +152,12 @@ if(BUSYQ_SSL)
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/src/embedded_certs.h")
         target_compile_definitions(busyq_main PRIVATE BUSYQ_EMBEDDED_CERTS)
     endif()
+endif()
+
+# Overlay: embedded script detection (uses zlib already linked via component libs)
+if(BUSYQ_OVERLAY)
+    target_sources(busyq_main PRIVATE src/overlay.c)
+    target_compile_definitions(busyq_main PRIVATE BUSYQ_OVERLAY)
 endif()
 
 # =====================================================================

--- a/Dockerfile
+++ b/Dockerfile
@@ -148,6 +148,7 @@ RUN if [ -f /tmp/busyq-scan ]; then \
     fi
 
 # Overlay tests: 2x2 matrix of binary (stripped / UPX) × script (raw / gzip)
+# UPX metadata after ELF segments is auto-detected and skipped.
 RUN set -e \
     && printf 'echo "BUSYQ_OVERLAY:$0:args=$#:${1-}:${2-}"\n' > /tmp/test.sh \
     && gzip -9c /tmp/test.sh > /tmp/test.sh.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,9 +58,10 @@ RUN grep '_BQ_IF(APPLET_' src/applets.h | grep 'APPLET(' | \
 # package installation (via vcpkg.json manifest) during cmake configure.
 RUN cmake --preset no-ssl && cmake --build --preset no-ssl
 
-# Strip and compress binaries; also copy library artifact
+# Strip and compress binaries; also copy library artifact (keep a pre-UPX copy for overlay tests)
 RUN strip --strip-all build/no-ssl/busyq \
     && mkdir -p out/busyq-dev \
+    && cp build/no-ssl/busyq out/busyq-nopack \
     && cp build/no-ssl/busyq out/busyq \
     && cp build/no-ssl/libbusyq.a out/libbusyq.a \
     && (upx --best --lzma out/busyq || true) \
@@ -97,6 +98,7 @@ RUN cp src/applet_table.h out/busyq-dev/ \
 # ============================================================
 FROM alpine:latest AS test
 COPY --from=build /src/out/busyq /busyq
+COPY --from=build /src/out/busyq-nopack /busyq-nopack
 COPY --from=build /src/out/busyq-ssl /busyq-ssl
 # Core (Phase 0-1)
 RUN /busyq -c 'echo "bash: ok"' \
@@ -144,6 +146,24 @@ RUN if [ -f /tmp/busyq-scan ]; then \
         && /tmp/busyq-scan --raw /tmp/test.sh | grep -q 'CMD' \
         && echo "Scanner smoke test passed"; \
     fi
+
+# Overlay tests: 2x2 matrix of binary (stripped / UPX) × script (raw / gzip)
+RUN set -e \
+    && printf 'echo "BUSYQ_OVERLAY:$0:args=$#:${1-}:${2-}"\n' > /tmp/test.sh \
+    && gzip -9c /tmp/test.sh > /tmp/test.sh.gz \
+    && cat /busyq-nopack /tmp/test.sh > /tmp/t1 && chmod +x /tmp/t1 \
+    && /tmp/t1 hello world | grep -q 'BUSYQ_OVERLAY:/tmp/t1:args=2:hello:world' \
+    && echo "overlay 1/4 passed: stripped + raw" \
+    && cat /busyq-nopack /tmp/test.sh.gz > /tmp/t2 && chmod +x /tmp/t2 \
+    && /tmp/t2 hello world | grep -q 'BUSYQ_OVERLAY:/tmp/t2:args=2:hello:world' \
+    && echo "overlay 2/4 passed: stripped + gzip" \
+    && cat /busyq /tmp/test.sh > /tmp/t3 && chmod +x /tmp/t3 \
+    && /tmp/t3 hello world | grep -q 'BUSYQ_OVERLAY:/tmp/t3:args=2:hello:world' \
+    && echo "overlay 3/4 passed: upx + raw" \
+    && cat /busyq /tmp/test.sh.gz > /tmp/t4 && chmod +x /tmp/t4 \
+    && /tmp/t4 hello world | grep -q 'BUSYQ_OVERLAY:/tmp/t4:args=2:hello:world' \
+    && echo "overlay 4/4 passed: upx + gzip" \
+    && echo "All overlay tests passed"
 
 # ============================================================
 # Stage 3: Extract binaries + libraries

--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,7 @@ RUN strip --strip-all build/ssl/busyq \
 # ---- Copy dev files for custom builds ----
 RUN cp src/applet_table.h out/busyq-dev/ \
     && cp src/applets.h out/busyq-dev/ \
-    && cp src/applets.c out/busyq-dev/ \
+    && cp src/features.c out/busyq-dev/ \
     && if [ -f out/busyq-scan ]; then \
         cp out/busyq-scan out/busyq-dev/; \
     fi

--- a/PLAN.md
+++ b/PLAN.md
@@ -32,7 +32,7 @@ prefixed libc names back to real ones, or use a linker script. The vcpkg
 portfile will generate the redefine-syms map automatically.
 
 ### Applet dispatch (replacing busybox)
-Applet registry in `src/applets.h` (X-macro) with dispatch in `src/applets.c`.
+Applet registry in `src/applets.h` (X-macro) with dispatch in `src/features.c`.
 Custom builds use `-DBUSYQ_CUSTOM_APPLETS -DAPPLET_<name>=1` to select
 applets at compile time; LTO strips unreferenced entry functions.
 The bash findcmd.c patches are already generic and need no changes.
@@ -52,7 +52,7 @@ sets argv[0] before calling.
 - [ ] Remove `ports/busyq-busybox/` vcpkg port
 - [ ] Remove `src/bb_namespace.h`
 - [ ] Remove `config/busybox.config`
-- [x] Refactor applet dispatch: replaced `src/applet_table.c` with `src/applets.h` (X-macro registry) + `src/applets.c` (preprocessor-filtered dispatch table).
+- [x] Refactor applet dispatch: replaced `src/applet_table.c` with `src/applets.h` (X-macro registry) + `src/features.c` (preprocessor-filtered dispatch table + feature gates).
 - [ ] Update `CMakeLists.txt`: remove libbusybox.a from link step
 - [ ] Update `vcpkg.json` manifest: remove busyq-busybox dependency
 - [ ] Verify: `busyq -c 'echo hello'` works, `busyq -c 'curl --version'` works, `busyq -c 'jq --version'` works

--- a/ports/busyq-bash/portfile.cmake
+++ b/ports/busyq-bash/portfile.cmake
@@ -36,11 +36,13 @@ file(COPY
 )
 file(RENAME "${SOURCE_PATH}/applet_table.h" "${SOURCE_PATH}/busyq_applet_table.h")
 
-# Provide a stub for busyq_find_applet so bash can link during its build.
-# The real implementation comes from applets.c at final link time.
+# Provide stubs for busyq_find_applet and busyq_check_overlay so bash
+# can link during its build.  The real implementations come from
+# features.c at final link time.
 file(WRITE "${SOURCE_PATH}/busyq_stub.c" [=[
 #include "busyq_applet_table.h"
 const struct busyq_applet *busyq_find_applet(const char *name) { (void)name; return 0; }
+char *busyq_check_overlay(size_t *out_len) { (void)out_len; return 0; }
 ]=])
 
 # Bash uses autotools.

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -214,7 +214,7 @@ echo "[7/7] Final link..."
 clang $LTO_CFLAGS -I"$PROJECT_DIR/src" \
     -c "$PROJECT_DIR/src/main.c" -o "$BUILD_DIR/main.o"
 clang $LTO_CFLAGS -I"$PROJECT_DIR/src" \
-    -c "$PROJECT_DIR/src/applets.c" -o "$BUILD_DIR/applet_table.o"
+    -c "$PROJECT_DIR/src/features.c" -o "$BUILD_DIR/applet_table.o"
 
 # Determine output binary name
 if [ "$SSL_MODE" = "mbedtls" ]; then

--- a/scripts/dev-container.sh
+++ b/scripts/dev-container.sh
@@ -186,6 +186,17 @@ dev-test() {
     dev-exec './build/no-ssl/busyq -c "echo -e \"b\na\nc\" | sort | head -1 | tr a-z A-Z && echo \"coreutils: ok\""'
     dev-exec './build/no-ssl/busyq -c "jq -n \"{test: true}\" && echo \"jq: ok\""'
     dev-exec './build/no-ssl/busyq -c "curl --version > /dev/null && echo \"curl: ok\""'
+
+    echo "=== Overlay tests ==="
+    # Write test script to project dir (bind-mounted at /src in the container)
+    printf 'echo "BUSYQ_OVERLAY:$0:args=$#:${1-}:${2-}"\n' > "${PROJECT_DIR}/.overlay-test.sh"
+    dev-exec 'gzip -9c .overlay-test.sh > /tmp/overlay-test.sh.gz'
+    # Raw script overlay
+    dev-exec 'cat ./build/no-ssl/busyq .overlay-test.sh > /tmp/overlay-raw && chmod +x /tmp/overlay-raw && /tmp/overlay-raw hello world | grep -q "BUSYQ_OVERLAY:/tmp/overlay-raw:args=2:hello:world" && echo "overlay raw: ok"'
+    # Gzip script overlay
+    dev-exec 'cat ./build/no-ssl/busyq /tmp/overlay-test.sh.gz > /tmp/overlay-gz && chmod +x /tmp/overlay-gz && /tmp/overlay-gz hello world | grep -q "BUSYQ_OVERLAY:/tmp/overlay-gz:args=2:hello:world" && echo "overlay gzip: ok"'
+    rm -f "${PROJECT_DIR}/.overlay-test.sh"
+
     echo "=== All smoke tests passed ==="
 }
 

--- a/src/applet_table.h
+++ b/src/applet_table.h
@@ -10,6 +10,8 @@
 #ifndef BUSYQ_APPLET_TABLE_H
 #define BUSYQ_APPLET_TABLE_H
 
+#include <stddef.h>
+
 /* Applet flags (reserved for future use) */
 #define BUSYQ_APPLET_NOFORK  (1 << 0)
 #define BUSYQ_APPLET_NOEXEC  (1 << 1)
@@ -27,5 +29,19 @@ struct busyq_applet {
  * Returns a pointer to the applet entry, or NULL if not found.
  */
 const struct busyq_applet *busyq_find_applet(const char *name);
+
+/*
+ * Check for an embedded script overlay appended after the ELF binary.
+ *
+ * When BUSYQ_OVERLAY is defined at features.c compile time, this
+ * calls the real overlay loader (busyq_load_overlay from overlay.c).
+ * Otherwise it is a no-op that returns NULL, allowing LTO to prune
+ * the overlay code entirely.
+ *
+ * Returns a malloc'd, null-terminated script string, or NULL if no
+ * overlay is present (or overlay support is disabled).  Caller must
+ * free().  Sets *out_len to the script length (excluding NUL).
+ */
+char *busyq_check_overlay(size_t *out_len);
 
 #endif /* BUSYQ_APPLET_TABLE_H */

--- a/src/applets.h
+++ b/src/applets.h
@@ -19,7 +19,7 @@
  *
  *   Example (direct cc):
  *     cc -DBUSYQ_CUSTOM_APPLETS -DAPPLET_curl=1 -DAPPLET_jq=1 \
- *        -DAPPLET_ls=1 src/applets.c -Isrc/ libbusyq.a ...
+ *        -DAPPLET_ls=1 src/features.c -Isrc/ libbusyq.a ...
  *
  *   Example (cmake):
  *     cmake --preset no-ssl -DBUSYQ_APPLETS="curl;jq;ls"

--- a/src/features.c
+++ b/src/features.c
@@ -1,25 +1,39 @@
 /*
- * applets.c — Applet dispatch for busyq
+ * features.c — Feature gates and applet dispatch for busyq
  *
- * Consumes applets.h (X-macro registry) to build the applet table at
- * compile time.  Only applets whose APPLET_<command> macro evaluates to 1
- * are included; their entry functions are the only symbols referenced,
- * allowing LTO to strip everything else.
+ * This is the only file recompiled during a lightweight custom build.
+ * It controls two things at compile time:
+ *
+ * 1. Applet selection — via the APPLET_<command> macros from applets.h.
+ *    Only applets whose flag evaluates to 1 appear in the dispatch table;
+ *    LTO prunes the entry functions (and transitive code) for the rest.
+ *
+ * 2. Feature flags — compile-time defines that gate optional subsystems.
+ *    When a feature is disabled its thunk returns a no-op value, letting
+ *    LTO strip the underlying implementation from the final binary.
+ *
+ *    Current feature flags:
+ *      BUSYQ_OVERLAY   Enable embedded-script overlay support.
  *
  * Full build (default):
- *   cc -Isrc/ src/applets.c ...
+ *   cc -DBUSYQ_OVERLAY -Isrc/ src/features.c ...
  *
- * Custom build (only selected applets):
+ * Custom build (only selected applets, no overlay):
  *   cc -DBUSYQ_CUSTOM_APPLETS -DAPPLET_curl=1 -DAPPLET_jq=1 \
- *      -Isrc/ src/applets.c ...
+ *      -Isrc/ src/features.c ...
  *
- * This file replaces gen-applet-table.sh — no code generation step
- * needed; the C preprocessor handles filtering directly.
+ * Custom build (selected applets + overlay):
+ *   cc -DBUSYQ_CUSTOM_APPLETS -DBUSYQ_OVERLAY -DAPPLET_curl=1 \
+ *      -Isrc/ src/features.c ...
  */
 
 #include "applet_table.h"
 #include <string.h>
 #include <unistd.h>
+
+#ifdef BUSYQ_OVERLAY
+#include "overlay.h"
+#endif
 
 /* Include applets.h to activate the default macros (APPLET_<cmd> = 0|1).
  * APPLET is not yet defined, so the no-op default in applets.h applies.
@@ -113,4 +127,22 @@ int busyq_help_main(int argc, char **argv)
     write(STDOUT_FILENO, "\n", 1);
 
     return 0;
+}
+
+/* ------------------------------------------------------------------ */
+/* Overlay — gate for embedded-script overlay support                  */
+/*                                                                     */
+/* When BUSYQ_OVERLAY is defined, this calls the real overlay loader   */
+/* (busyq_load_overlay in overlay.c).  Otherwise it returns NULL,      */
+/* and LTO prunes the overlay code (ELF parsing, zlib, etc.).          */
+/* ------------------------------------------------------------------ */
+
+char *busyq_check_overlay(size_t *out_len)
+{
+#ifdef BUSYQ_OVERLAY
+    return busyq_load_overlay(out_len);
+#else
+    (void)out_len;
+    return NULL;
+#endif
 }

--- a/src/main.c
+++ b/src/main.c
@@ -5,21 +5,15 @@
  * /proc/self/exe with argv[0] set to an applet name (e.g. curl needing
  * ssl_client), we dispatch to the applet instead of starting bash.
  *
- * If BUSYQ_OVERLAY is enabled and a script is appended after the ELF
- * binary (overlay data), the script is loaded and executed with all
- * command-line arguments forwarded to it.
- *
- * Bash's own argv[0] semantics are preserved: "sh" enters POSIX mode,
- * "bash" / "busyq" / anything unrecognised falls through to bash.
+ * If overlay support is enabled (via BUSYQ_OVERLAY at features.c
+ * compile time) and a script is appended after the ELF binary, the
+ * script is loaded and executed with all command-line arguments
+ * forwarded to it.
  */
 
 #include "applet_table.h"
-#include <string.h>
-
-#ifdef BUSYQ_OVERLAY
-#include "overlay.h"
 #include <stdlib.h>
-#endif
+#include <string.h>
 
 /* Declared in bash's shell.h, but we just need the prototype */
 extern int bash_main(int argc, char **argv);
@@ -48,18 +42,22 @@ int main(int argc, char **argv)
             return applet->main_func(argc, argv);
     }
 
-#ifdef BUSYQ_OVERLAY
     /*
      * Check for an embedded script overlay.  If present, run it via
      * bash -c with the original argv[0] as $0 and remaining args as
      * positional parameters.
+     *
+     * busyq_check_overlay() is a thunk defined in features.c that
+     * calls the real overlay loader when BUSYQ_OVERLAY is defined,
+     * or returns NULL (no-op) otherwise.  In the no-op case LTO
+     * prunes all overlay-related code (ELF parsing, zlib, etc.).
      *
      * This runs after applet dispatch so that internal re-exec (e.g.
      * ssl_client) still works even when an overlay is attached.
      */
     {
         size_t script_len;
-        char *script = busyq_load_overlay(&script_len);
+        char *script = busyq_check_overlay(&script_len);
 
         if (script) {
             /*
@@ -93,7 +91,6 @@ int main(int argc, char **argv)
             return ret;
         }
     }
-#endif
 
     return bash_main(argc, argv);
 }

--- a/src/main.c
+++ b/src/main.c
@@ -5,12 +5,21 @@
  * /proc/self/exe with argv[0] set to an applet name (e.g. curl needing
  * ssl_client), we dispatch to the applet instead of starting bash.
  *
+ * If BUSYQ_OVERLAY is enabled and a script is appended after the ELF
+ * binary (overlay data), the script is loaded and executed with all
+ * command-line arguments forwarded to it.
+ *
  * Bash's own argv[0] semantics are preserved: "sh" enters POSIX mode,
  * "bash" / "busyq" / anything unrecognised falls through to bash.
  */
 
 #include "applet_table.h"
 #include <string.h>
+
+#ifdef BUSYQ_OVERLAY
+#include "overlay.h"
+#include <stdlib.h>
+#endif
 
 /* Declared in bash's shell.h, but we just need the prototype */
 extern int bash_main(int argc, char **argv);
@@ -38,6 +47,53 @@ int main(int argc, char **argv)
         if (applet)
             return applet->main_func(argc, argv);
     }
+
+#ifdef BUSYQ_OVERLAY
+    /*
+     * Check for an embedded script overlay.  If present, run it via
+     * bash -c with the original argv[0] as $0 and remaining args as
+     * positional parameters.
+     *
+     * This runs after applet dispatch so that internal re-exec (e.g.
+     * ssl_client) still works even when an overlay is attached.
+     */
+    {
+        size_t script_len;
+        char *script = busyq_load_overlay(&script_len);
+
+        if (script) {
+            /*
+             * Build: bash -c <script> <argv[0]> <argv[1]> ...
+             *
+             * In bash -c mode:
+             *   argv[0] of bash_main is ignored for $0 purposes
+             *   the -c string is the script
+             *   next arg becomes $0 in the script
+             *   remaining args become $1, $2, ...
+             */
+            int i, ret;
+            int new_argc = 3 + argc;
+            char **new_argv = calloc((size_t)new_argc + 1, sizeof(char *));
+
+            if (!new_argv) {
+                free(script);
+                return 1;
+            }
+
+            new_argv[0] = (char *)"bash";
+            new_argv[1] = (char *)"-c";
+            new_argv[2] = script;
+            for (i = 0; i < argc; i++)
+                new_argv[3 + i] = argv[i];
+            new_argv[new_argc] = NULL;
+
+            ret = bash_main(new_argc, new_argv);
+            free(new_argv);
+            free(script);
+            return ret;
+        }
+    }
+#endif
 
     return bash_main(argc, argv);
 }

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -5,9 +5,9 @@
  * the ELF headers to find the logical end of the file.  Works for
  * both regular and UPX-compressed binaries.
  *
- * For UPX-compressed binaries, UPX metadata after the ELF segments
- * is automatically detected and skipped by scanning forward for
- * valid script content (gzip magic or printable text).
+ * For UPX-compressed binaries, the 36-byte UPX trailer (PackHeader +
+ * overlay_offset) after the ELF segments is deterministically parsed
+ * and skipped.
  *
  * The overlay payload may be raw script text or gzip-compressed
  * data (auto-detected via 0x1f 0x8b magic).
@@ -211,58 +211,54 @@ static int is_upx_binary(int fd)
 }
 
 /*
- * Check if a byte is a valid text character (printable ASCII,
- * tab, newline, or carriage return).
+ * Compute the size of UPX's end-of-file trailer from post-ELF data.
+ *
+ * UPX's pack4() writes a PackHeader followed by a 4-byte overlay_offset
+ * as the very last data in the file (see p_unix.cpp in UPX source).
+ * The PackHeader starts with "UPX!" magic (0x55505821 LE32) and its
+ * size depends on the version and format fields at bytes 4-5:
+ *
+ *   version >= 10, non-DOS format:  32 bytes  (current UPX)
+ *   version  4-9, non-DOS format:   28 bytes
+ *   version <= 3:                    24 bytes
+ *
+ * Total trailer = PackHeader + 4-byte overlay_offset.
+ *
+ * Returns the trailer size in bytes, or 0 if the data doesn't start
+ * with a valid UPX PackHeader.
  */
-static int is_text_byte(unsigned char c)
+static size_t upx_trailer_size(const unsigned char *data, size_t len)
 {
-    return (c >= 0x20 && c <= 0x7e) ||
-           c == '\t' || c == '\n' || c == '\r';
-}
+    int version, format;
+    int phdr_size;
 
-/*
- * Find the start of a script overlay within post-ELF data, skipping
- * any leading binary metadata (e.g. UPX pack header and overlay offset).
- *
- * Scans forward looking for:
- *   1. Gzip magic (0x1f 0x8b) — indicates gzip-compressed script
- *   2. 16+ consecutive valid text bytes — indicates raw script text
- *
- * UPX metadata is typically ~36 bytes of structured binary data
- * (pack header + overlay offset), which fails both checks.
- *
- * Returns the byte offset, or (size_t)-1 if no script found.
- */
-#define OVERLAY_TEXT_MIN 16   /* min consecutive text bytes for detection */
-#define OVERLAY_SCAN_MAX 256  /* max bytes to scan for overlay start */
+    /* Need at least magic(4) + version/format(2) */
+    if (len < 6)
+        return 0;
 
-static size_t find_script_start(const unsigned char *data, size_t len)
-{
-    size_t off;
-    size_t limit = len < OVERLAY_SCAN_MAX ? len : OVERLAY_SCAN_MAX;
+    /* PackHeader starts with "UPX!" magic (LE32: 0x55505821) */
+    if (data[0] != 'U' || data[1] != 'P' ||
+        data[2] != 'X' || data[3] != '!')
+        return 0;
 
-    for (off = 0; off < limit; off++) {
-        /* Check for gzip magic */
-        if (off + 1 < len &&
-            data[off] == 0x1f && data[off + 1] == 0x8b)
-            return off;
+    version = data[4];
+    format = data[5];
 
-        /* Check for consecutive valid text bytes */
-        if (off + OVERLAY_TEXT_MIN <= len) {
-            size_t i;
-            int valid = 1;
-            for (i = 0; i < OVERLAY_TEXT_MIN; i++) {
-                if (!is_text_byte(data[off + i])) {
-                    valid = 0;
-                    break;
-                }
-            }
-            if (valid)
-                return off;
-        }
-    }
+    /* PackHeader size from UPX packhead.cpp getPackHeaderSize() */
+    if (version <= 3)
+        phdr_size = 24;
+    else if (format == 1 || format == 2)   /* UPX_F_DOS_COM, UPX_F_DOS_SYS */
+        phdr_size = (version <= 9) ? 20 : 22;
+    else if (format == 3 || format == 4)   /* UPX_F_DOS_EXE, UPX_F_DOS_EXEH */
+        phdr_size = (version <= 9) ? 25 : 27;
+    else                                   /* ELF and all other formats */
+        phdr_size = (version <= 9) ? 28 : 32;
 
-    return (size_t)-1;
+    /* Trailer = PackHeader + 4-byte overlay_offset */
+    if ((size_t)(phdr_size + 4) > len)
+        return 0;
+
+    return (size_t)(phdr_size + 4);
 }
 
 char *busyq_load_overlay(size_t *out_len)
@@ -316,17 +312,18 @@ char *busyq_load_overlay(size_t *out_len)
 
     if (upx) {
         /*
-         * UPX leaves metadata after ELF segments (pack header +
-         * overlay offset, typically ~36 bytes).  Scan forward to
-         * find where the actual script data begins.
+         * UPX appends a PackHeader (32 bytes for modern ELF) plus a
+         * 4-byte overlay_offset as the last data in the file, after
+         * all ELF structures.  Parse the trailer size exactly and
+         * skip it to find the user's overlay data.
          */
-        size_t script_off = find_script_start(raw, overlay_len);
-        if (script_off == (size_t)-1) {
+        size_t trailer = upx_trailer_size(raw, overlay_len);
+        if (trailer == 0 || trailer >= overlay_len) {
             free(raw);
             return NULL;  /* UPX metadata only, no script overlay */
         }
-        data = raw + script_off;
-        data_len = overlay_len - script_off;
+        data = raw + trailer;
+        data_len = overlay_len - trailer;
     }
 
     /* Auto-detect gzip: magic bytes 0x1f 0x8b */

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -5,9 +5,11 @@
  * the ELF headers to find the logical end of the file.  Works for
  * both regular and UPX-compressed binaries.
  *
- * For UPX-compressed binaries, the 36-byte UPX trailer (PackHeader +
- * overlay_offset) after the ELF segments is deterministically parsed
- * and skipped.
+ * For UPX-compressed binaries, the post-ELF region contains UPX
+ * metadata (decompressor stub, padding, PackHeader, overlay_offset).
+ * We scan for a valid UPX PackHeader (32-byte structure with "UPX!"
+ * magic + checksum) and skip past it + the 4-byte overlay_offset to
+ * find user-appended data.
  *
  * The overlay payload may be raw script text or gzip-compressed
  * data (auto-detected via 0x1f 0x8b magic).
@@ -179,86 +181,58 @@ static char *gunzip(const unsigned char *data, size_t len, size_t *out_len)
 }
 
 /*
- * Check if the ELF binary was compressed with UPX.
+ * Scan post-ELF data for a valid UPX PackHeader and return the offset
+ * where user overlay data begins (right after the trailer).
  *
- * UPX places an l_info structure immediately after the program header
- * table.  The l_magic field (at offset 4 within l_info) contains
- * "UPX!" (0x55505821) for UPX-compressed binaries.
+ * UPX appends metadata after the ELF segments: decompressor stub,
+ * metadata words, padding, and finally a 32-byte PackHeader followed
+ * by a 4-byte overlay_offset.  The PackHeader contains "UPX!" magic
+ * at bytes [0..3] and a checksum at byte [31] (sum of bytes [4..30]
+ * mod 251).  We scan for this signature to find the UPX/user boundary.
+ *
+ * Returns the byte offset within 'data' where user data starts
+ * (i.e. right after PackHeader + overlay_offset), or 0 if no valid
+ * PackHeader is found (meaning no UPX metadata to skip).
  */
-static int is_upx_binary(int fd)
+static size_t find_upx_trailer_end(const unsigned char *data, size_t len)
 {
-    Elf64_Ehdr ehdr;
-    unsigned char magic[4];
-    off_t l_info_off;
+    size_t off;
 
-    if (pread(fd, &ehdr, sizeof(ehdr), 0) != (ssize_t)sizeof(ehdr))
-        return 0;
-    if (memcmp(ehdr.e_ident, ELFMAG, SELFMAG) != 0)
-        return 0;
-    if (ehdr.e_ident[EI_CLASS] != ELFCLASS64)
+    /* PackHeader(32) + overlay_offset(4) = 36 bytes minimum */
+    if (len < 36)
         return 0;
 
-    /* l_info is right after the program header table */
-    l_info_off = (off_t)ehdr.e_phoff +
-                 (off_t)ehdr.e_phnum * ehdr.e_phentsize;
+    for (off = 0; off + 36 <= len; off++) {
+        unsigned sum;
+        int j;
 
-    /* l_magic is at offset 4 within l_info */
-    if (pread(fd, magic, 4, l_info_off + 4) != 4)
-        return 0;
+        /* Look for "UPX!" magic */
+        if (data[off]   != 'U' || data[off+1] != 'P' ||
+            data[off+2] != 'X' || data[off+3] != '!')
+            continue;
 
-    return magic[0] == 'U' && magic[1] == 'P' &&
-           magic[2] == 'X' && magic[3] == '!';
-}
+        /* Validate version (byte 4): 1..63 covers all known and
+         * foreseeable UPX versions without being too permissive */
+        if (data[off+4] < 1 || data[off+4] > 63)
+            continue;
 
-/*
- * Compute the size of UPX's end-of-file trailer from post-ELF data.
- *
- * UPX's pack4() writes a PackHeader followed by a 4-byte overlay_offset
- * as the very last data in the file (see p_unix.cpp in UPX source).
- * The PackHeader starts with "UPX!" magic (0x55505821 LE32) and its
- * size depends on the version and format fields at bytes 4-5:
- *
- *   version >= 10, non-DOS format:  32 bytes  (current UPX)
- *   version  4-9, non-DOS format:   28 bytes
- *   version <= 3:                    24 bytes
- *
- * Total trailer = PackHeader + 4-byte overlay_offset.
- *
- * Returns the trailer size in bytes, or 0 if the data doesn't start
- * with a valid UPX PackHeader.
- */
-static size_t upx_trailer_size(const unsigned char *data, size_t len)
-{
-    int version, format;
-    int phdr_size;
+        /* Validate format (byte 5): must be non-zero */
+        if (data[off+5] == 0)
+            continue;
 
-    /* Need at least magic(4) + version/format(2) */
-    if (len < 6)
-        return 0;
+        /* Validate PackHeader checksum: sum of bytes [4..30] mod 251 */
+        sum = 0;
+        for (j = 4; j <= 30; j++)
+            sum += data[off + j];
+        if (data[off+31] != (unsigned char)(sum % 251))
+            continue;
 
-    /* PackHeader starts with "UPX!" magic (LE32: 0x55505821) */
-    if (data[0] != 'U' || data[1] != 'P' ||
-        data[2] != 'X' || data[3] != '!')
-        return 0;
+        /* Valid PackHeader found.  User data starts after the
+         * 32-byte PackHeader + 4-byte overlay_offset. */
+        return off + 36;
+    }
 
-    version = data[4];
-    format = data[5];
-
-    /* PackHeader size from UPX packhead.cpp getPackHeaderSize() */
-    if (version <= 3)
-        phdr_size = 24;
-    else if (format == 1 || format == 2)   /* UPX_F_DOS_COM, UPX_F_DOS_SYS */
-        phdr_size = (version <= 9) ? 20 : 22;
-    else if (format == 3 || format == 4)   /* UPX_F_DOS_EXE, UPX_F_DOS_EXEH */
-        phdr_size = (version <= 9) ? 25 : 27;
-    else                                   /* ELF and all other formats */
-        phdr_size = (version <= 9) ? 28 : 32;
-
-    /* Trailer = PackHeader + 4-byte overlay_offset */
-    if ((size_t)(phdr_size + 4) > len)
-        return 0;
-
-    return (size_t)(phdr_size + 4);
+    return 0;
 }
 
 char *busyq_load_overlay(size_t *out_len)
@@ -270,7 +244,6 @@ char *busyq_load_overlay(size_t *out_len)
     unsigned char *raw;
     unsigned char *data;
     size_t data_len;
-    int upx;
     char *script;
 
     fd = open("/proc/self/exe", O_RDONLY);
@@ -302,28 +275,34 @@ char *busyq_load_overlay(size_t *out_len)
         close(fd);
         return NULL;
     }
-
-    /* Detect UPX compression */
-    upx = is_upx_binary(fd);
     close(fd);
 
     data = raw;
     data_len = overlay_len;
 
-    if (upx) {
-        /*
-         * UPX appends a PackHeader (32 bytes for modern ELF) plus a
-         * 4-byte overlay_offset as the last data in the file, after
-         * all ELF structures.  Parse the trailer size exactly and
-         * skip it to find the user's overlay data.
-         */
-        size_t trailer = upx_trailer_size(raw, overlay_len);
-        if (trailer == 0 || trailer >= overlay_len) {
-            free(raw);
-            return NULL;  /* UPX metadata only, no script overlay */
+    /*
+     * Check for UPX metadata in the post-ELF region.
+     *
+     * UPX places metadata (decompressor stub, padding, PackHeader,
+     * overlay_offset) after the ELF segments.  The PackHeader is a
+     * 32-byte structure starting with "UPX!" magic and ending with
+     * a checksum, followed by a 4-byte overlay_offset.  We scan for
+     * this signature to find where UPX metadata ends and any
+     * user-appended overlay data begins.
+     *
+     * This works regardless of whether PT_NOTE data, padding, or
+     * other structures sit between the segment end and the trailer.
+     */
+    {
+        size_t upx_end = find_upx_trailer_end(raw, overlay_len);
+        if (upx_end > 0) {
+            if (upx_end >= overlay_len) {
+                free(raw);
+                return NULL;  /* UPX metadata only, no user overlay */
+            }
+            data = raw + upx_end;
+            data_len = overlay_len - upx_end;
         }
-        data = raw + trailer;
-        data_len = overlay_len - trailer;
     }
 
     /* Auto-detect gzip: magic bytes 0x1f 0x8b */

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -1,0 +1,234 @@
+/*
+ * overlay.c - Embedded script overlay support for busyq
+ *
+ * Detects data appended after the ELF binary ("overlay") by parsing
+ * the ELF headers to find the logical end of the file.  Works for
+ * both regular and UPX-compressed binaries (UPX produces valid ELF
+ * files with no section headers, so we handle that case).
+ *
+ * Gzip-compressed overlays are auto-detected (magic 0x1f 0x8b) and
+ * transparently decompressed using zlib.
+ */
+
+#include "overlay.h"
+
+#include <elf.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <zlib.h>
+
+/*
+ * Calculate the logical end of an ELF64 file by examining all
+ * headers and segments.  Any data beyond this offset is overlay.
+ *
+ * We take the maximum of:
+ *   - ELF header size
+ *   - Program header table end
+ *   - Section header table end  (may be 0 after strip/UPX)
+ *   - Each segment's file end   (p_offset + p_filesz)
+ *   - Each section's file end   (sh_offset + sh_size, skip NOBITS)
+ *
+ * Returns the offset, or (off_t)-1 on error.
+ */
+static off_t elf_file_end(int fd)
+{
+    Elf64_Ehdr ehdr;
+    off_t end;
+    int i;
+
+    if (pread(fd, &ehdr, sizeof(ehdr), 0) != (ssize_t)sizeof(ehdr))
+        return (off_t)-1;
+
+    /* Verify ELF magic */
+    if (memcmp(ehdr.e_ident, ELFMAG, SELFMAG) != 0)
+        return (off_t)-1;
+
+    /* Only handle 64-bit (project target is x86_64) */
+    if (ehdr.e_ident[EI_CLASS] != ELFCLASS64)
+        return (off_t)-1;
+
+    end = (off_t)sizeof(ehdr);
+
+    /* Program header table end */
+    if (ehdr.e_phoff) {
+        off_t ph_end = (off_t)ehdr.e_phoff +
+                       (off_t)ehdr.e_phnum * ehdr.e_phentsize;
+        if (ph_end > end)
+            end = ph_end;
+    }
+
+    /* Section header table end (0 if stripped / UPX'd) */
+    if (ehdr.e_shoff) {
+        off_t sh_end = (off_t)ehdr.e_shoff +
+                       (off_t)ehdr.e_shnum * ehdr.e_shentsize;
+        if (sh_end > end)
+            end = sh_end;
+    }
+
+    /* Scan program headers for segment data ends */
+    for (i = 0; i < ehdr.e_phnum; i++) {
+        Elf64_Phdr phdr;
+        off_t seg_end;
+        off_t off = (off_t)ehdr.e_phoff + (off_t)i * ehdr.e_phentsize;
+
+        if (pread(fd, &phdr, sizeof(phdr), off) != (ssize_t)sizeof(phdr))
+            return (off_t)-1;
+
+        seg_end = (off_t)phdr.p_offset + (off_t)phdr.p_filesz;
+        if (seg_end > end)
+            end = seg_end;
+    }
+
+    /* Scan section headers for section data ends */
+    for (i = 0; i < ehdr.e_shnum; i++) {
+        Elf64_Shdr shdr;
+        off_t sec_end;
+        off_t off = (off_t)ehdr.e_shoff + (off_t)i * ehdr.e_shentsize;
+
+        if (pread(fd, &shdr, sizeof(shdr), off) != (ssize_t)sizeof(shdr))
+            return (off_t)-1;
+
+        /* SHT_NOBITS sections (.bss) occupy no file space */
+        if (shdr.sh_type == SHT_NOBITS)
+            continue;
+
+        sec_end = (off_t)shdr.sh_offset + (off_t)shdr.sh_size;
+        if (sec_end > end)
+            end = sec_end;
+    }
+
+    return end;
+}
+
+/*
+ * Decompress gzip data using zlib.
+ * Returns a malloc'd, null-terminated buffer, or NULL on error.
+ * Sets *out_len to the decompressed length.
+ */
+static char *gunzip(const unsigned char *data, size_t len, size_t *out_len)
+{
+    z_stream strm;
+    size_t buf_size;
+    char *buf, *tmp;
+    int ret;
+
+    memset(&strm, 0, sizeof(strm));
+    strm.next_in = (Bytef *)data;
+    strm.avail_in = (uInt)len;
+
+    /* windowBits = 15 + 16 tells zlib to detect/handle gzip header */
+    if (inflateInit2(&strm, 15 + 16) != Z_OK)
+        return NULL;
+
+    buf_size = len * 4;  /* initial guess */
+    if (buf_size < 4096)
+        buf_size = 4096;
+
+    buf = malloc(buf_size);
+    if (!buf) {
+        inflateEnd(&strm);
+        return NULL;
+    }
+
+    strm.next_out = (unsigned char *)buf;
+    strm.avail_out = (uInt)buf_size;
+
+    for (;;) {
+        ret = inflate(&strm, Z_FINISH);
+        if (ret == Z_STREAM_END)
+            break;
+
+        if (ret == Z_BUF_ERROR || (ret == Z_OK && strm.avail_out == 0)) {
+            /* Need more output space */
+            size_t have = (size_t)(strm.next_out - (unsigned char *)buf);
+            buf_size *= 2;
+            tmp = realloc(buf, buf_size);
+            if (!tmp) {
+                free(buf);
+                inflateEnd(&strm);
+                return NULL;
+            }
+            buf = tmp;
+            strm.next_out = (unsigned char *)buf + have;
+            strm.avail_out = (uInt)(buf_size - have);
+            continue;
+        }
+
+        /* Decompression error */
+        free(buf);
+        inflateEnd(&strm);
+        return NULL;
+    }
+
+    *out_len = strm.total_out;
+    inflateEnd(&strm);
+
+    /* Null-terminate for use as C string */
+    tmp = realloc(buf, *out_len + 1);
+    if (tmp)
+        buf = tmp;
+    buf[*out_len] = '\0';
+
+    return buf;
+}
+
+char *busyq_load_overlay(size_t *out_len)
+{
+    int fd;
+    struct stat st;
+    off_t elf_end;
+    size_t overlay_len;
+    char *overlay;
+    char *script;
+
+    fd = open("/proc/self/exe", O_RDONLY);
+    if (fd < 0)
+        return NULL;
+
+    if (fstat(fd, &st) < 0) {
+        close(fd);
+        return NULL;
+    }
+
+    elf_end = elf_file_end(fd);
+    if (elf_end <= 0 || elf_end >= st.st_size) {
+        close(fd);
+        return NULL;  /* No overlay data */
+    }
+
+    overlay_len = (size_t)(st.st_size - elf_end);
+    if (overlay_len == 0) {
+        close(fd);
+        return NULL;
+    }
+
+    overlay = malloc(overlay_len + 1);
+    if (!overlay) {
+        close(fd);
+        return NULL;
+    }
+
+    if (pread(fd, overlay, overlay_len, elf_end) != (ssize_t)overlay_len) {
+        free(overlay);
+        close(fd);
+        return NULL;
+    }
+    close(fd);
+
+    /* Auto-detect gzip: magic bytes 0x1f 0x8b */
+    if (overlay_len >= 2 &&
+        (unsigned char)overlay[0] == 0x1f &&
+        (unsigned char)overlay[1] == 0x8b) {
+        script = gunzip((unsigned char *)overlay, overlay_len, out_len);
+        free(overlay);
+        return script;  /* NULL on decompress error */
+    }
+
+    /* Not compressed — use as-is, null-terminate */
+    overlay[overlay_len] = '\0';
+    *out_len = overlay_len;
+    return overlay;
+}

--- a/src/overlay.c
+++ b/src/overlay.c
@@ -3,11 +3,14 @@
  *
  * Detects data appended after the ELF binary ("overlay") by parsing
  * the ELF headers to find the logical end of the file.  Works for
- * both regular and UPX-compressed binaries (UPX produces valid ELF
- * files with no section headers, so we handle that case).
+ * both regular and UPX-compressed binaries.
  *
- * Gzip-compressed overlays are auto-detected (magic 0x1f 0x8b) and
- * transparently decompressed using zlib.
+ * For UPX-compressed binaries, UPX metadata after the ELF segments
+ * is automatically detected and skipped by scanning forward for
+ * valid script content (gzip magic or printable text).
+ *
+ * The overlay payload may be raw script text or gzip-compressed
+ * data (auto-detected via 0x1f 0x8b magic).
  */
 
 #include "overlay.h"
@@ -175,13 +178,103 @@ static char *gunzip(const unsigned char *data, size_t len, size_t *out_len)
     return buf;
 }
 
+/*
+ * Check if the ELF binary was compressed with UPX.
+ *
+ * UPX places an l_info structure immediately after the program header
+ * table.  The l_magic field (at offset 4 within l_info) contains
+ * "UPX!" (0x55505821) for UPX-compressed binaries.
+ */
+static int is_upx_binary(int fd)
+{
+    Elf64_Ehdr ehdr;
+    unsigned char magic[4];
+    off_t l_info_off;
+
+    if (pread(fd, &ehdr, sizeof(ehdr), 0) != (ssize_t)sizeof(ehdr))
+        return 0;
+    if (memcmp(ehdr.e_ident, ELFMAG, SELFMAG) != 0)
+        return 0;
+    if (ehdr.e_ident[EI_CLASS] != ELFCLASS64)
+        return 0;
+
+    /* l_info is right after the program header table */
+    l_info_off = (off_t)ehdr.e_phoff +
+                 (off_t)ehdr.e_phnum * ehdr.e_phentsize;
+
+    /* l_magic is at offset 4 within l_info */
+    if (pread(fd, magic, 4, l_info_off + 4) != 4)
+        return 0;
+
+    return magic[0] == 'U' && magic[1] == 'P' &&
+           magic[2] == 'X' && magic[3] == '!';
+}
+
+/*
+ * Check if a byte is a valid text character (printable ASCII,
+ * tab, newline, or carriage return).
+ */
+static int is_text_byte(unsigned char c)
+{
+    return (c >= 0x20 && c <= 0x7e) ||
+           c == '\t' || c == '\n' || c == '\r';
+}
+
+/*
+ * Find the start of a script overlay within post-ELF data, skipping
+ * any leading binary metadata (e.g. UPX pack header and overlay offset).
+ *
+ * Scans forward looking for:
+ *   1. Gzip magic (0x1f 0x8b) — indicates gzip-compressed script
+ *   2. 16+ consecutive valid text bytes — indicates raw script text
+ *
+ * UPX metadata is typically ~36 bytes of structured binary data
+ * (pack header + overlay offset), which fails both checks.
+ *
+ * Returns the byte offset, or (size_t)-1 if no script found.
+ */
+#define OVERLAY_TEXT_MIN 16   /* min consecutive text bytes for detection */
+#define OVERLAY_SCAN_MAX 256  /* max bytes to scan for overlay start */
+
+static size_t find_script_start(const unsigned char *data, size_t len)
+{
+    size_t off;
+    size_t limit = len < OVERLAY_SCAN_MAX ? len : OVERLAY_SCAN_MAX;
+
+    for (off = 0; off < limit; off++) {
+        /* Check for gzip magic */
+        if (off + 1 < len &&
+            data[off] == 0x1f && data[off + 1] == 0x8b)
+            return off;
+
+        /* Check for consecutive valid text bytes */
+        if (off + OVERLAY_TEXT_MIN <= len) {
+            size_t i;
+            int valid = 1;
+            for (i = 0; i < OVERLAY_TEXT_MIN; i++) {
+                if (!is_text_byte(data[off + i])) {
+                    valid = 0;
+                    break;
+                }
+            }
+            if (valid)
+                return off;
+        }
+    }
+
+    return (size_t)-1;
+}
+
 char *busyq_load_overlay(size_t *out_len)
 {
     int fd;
     struct stat st;
     off_t elf_end;
     size_t overlay_len;
-    char *overlay;
+    unsigned char *raw;
+    unsigned char *data;
+    size_t data_len;
+    int upx;
     char *script;
 
     fd = open("/proc/self/exe", O_RDONLY);
@@ -200,35 +293,59 @@ char *busyq_load_overlay(size_t *out_len)
     }
 
     overlay_len = (size_t)(st.st_size - elf_end);
-    if (overlay_len == 0) {
+
+    /* Read all post-ELF data */
+    raw = malloc(overlay_len);
+    if (!raw) {
         close(fd);
         return NULL;
     }
 
-    overlay = malloc(overlay_len + 1);
-    if (!overlay) {
+    if (pread(fd, raw, overlay_len, elf_end) != (ssize_t)overlay_len) {
+        free(raw);
         close(fd);
         return NULL;
     }
 
-    if (pread(fd, overlay, overlay_len, elf_end) != (ssize_t)overlay_len) {
-        free(overlay);
-        close(fd);
-        return NULL;
-    }
+    /* Detect UPX compression */
+    upx = is_upx_binary(fd);
     close(fd);
 
+    data = raw;
+    data_len = overlay_len;
+
+    if (upx) {
+        /*
+         * UPX leaves metadata after ELF segments (pack header +
+         * overlay offset, typically ~36 bytes).  Scan forward to
+         * find where the actual script data begins.
+         */
+        size_t script_off = find_script_start(raw, overlay_len);
+        if (script_off == (size_t)-1) {
+            free(raw);
+            return NULL;  /* UPX metadata only, no script overlay */
+        }
+        data = raw + script_off;
+        data_len = overlay_len - script_off;
+    }
+
     /* Auto-detect gzip: magic bytes 0x1f 0x8b */
-    if (overlay_len >= 2 &&
-        (unsigned char)overlay[0] == 0x1f &&
-        (unsigned char)overlay[1] == 0x8b) {
-        script = gunzip((unsigned char *)overlay, overlay_len, out_len);
-        free(overlay);
+    if (data_len >= 2 &&
+        data[0] == 0x1f && data[1] == 0x8b) {
+        script = gunzip(data, data_len, out_len);
+        free(raw);
         return script;  /* NULL on decompress error */
     }
 
-    /* Not compressed — use as-is, null-terminate */
-    overlay[overlay_len] = '\0';
-    *out_len = overlay_len;
-    return overlay;
+    /* Not compressed — copy, null-terminate, return */
+    script = malloc(data_len + 1);
+    if (!script) {
+        free(raw);
+        return NULL;
+    }
+    memcpy(script, data, data_len);
+    script[data_len] = '\0';
+    *out_len = data_len;
+    free(raw);
+    return script;
 }

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -2,18 +2,18 @@
  * overlay.h - Embedded script overlay support for busyq
  *
  * Detects and loads bash scripts appended after the ELF binary
- * (overlay data).  Scripts may be raw text or gzip-compressed.
+ * (overlay data).  Supports both raw text and gzip-compressed
+ * payloads (auto-detected via gzip magic).
  *
  * Compatible with UPX: compress with UPX first, then append the
- * overlay.  UPX does not preserve ELF overlays, so the overlay
- * must be attached after UPX compression.
+ * overlay.  UPX metadata is automatically detected and skipped.
  *
  * Attachment examples:
  *   # Raw script:
  *   cat busyq myscript.sh > mybinary && chmod +x mybinary
  *
  *   # Gzip-compressed script:
- *   gzip -9c myscript.sh | cat busyq - > mybinary && chmod +x mybinary
+ *   { cat busyq; gzip -9c myscript.sh; } > mybinary && chmod +x mybinary
  *
  *   # After UPX:
  *   upx --best -o busyq-upx busyq
@@ -29,8 +29,9 @@
  * Try to load an overlay script from /proc/self/exe.
  *
  * Examines the ELF headers to find where the binary ends, then
- * reads any data appended beyond that point.  If the data begins
- * with a gzip magic (0x1f 0x8b), it is automatically decompressed.
+ * reads any data appended beyond that point.  For UPX-compressed
+ * binaries, UPX metadata is automatically skipped.  If the payload
+ * begins with gzip magic (0x1f 0x8b), it is automatically decompressed.
  *
  * Returns a malloc'd, null-terminated string containing the script,
  * or NULL if no overlay is present.  Caller must free().

--- a/src/overlay.h
+++ b/src/overlay.h
@@ -1,0 +1,41 @@
+/*
+ * overlay.h - Embedded script overlay support for busyq
+ *
+ * Detects and loads bash scripts appended after the ELF binary
+ * (overlay data).  Scripts may be raw text or gzip-compressed.
+ *
+ * Compatible with UPX: compress with UPX first, then append the
+ * overlay.  UPX does not preserve ELF overlays, so the overlay
+ * must be attached after UPX compression.
+ *
+ * Attachment examples:
+ *   # Raw script:
+ *   cat busyq myscript.sh > mybinary && chmod +x mybinary
+ *
+ *   # Gzip-compressed script:
+ *   gzip -9c myscript.sh | cat busyq - > mybinary && chmod +x mybinary
+ *
+ *   # After UPX:
+ *   upx --best -o busyq-upx busyq
+ *   cat busyq-upx myscript.sh > mybinary && chmod +x mybinary
+ */
+
+#ifndef BUSYQ_OVERLAY_H
+#define BUSYQ_OVERLAY_H
+
+#include <stddef.h>
+
+/*
+ * Try to load an overlay script from /proc/self/exe.
+ *
+ * Examines the ELF headers to find where the binary ends, then
+ * reads any data appended beyond that point.  If the data begins
+ * with a gzip magic (0x1f 0x8b), it is automatically decompressed.
+ *
+ * Returns a malloc'd, null-terminated string containing the script,
+ * or NULL if no overlay is present.  Caller must free().
+ * Sets *out_len to the script length (excluding null terminator).
+ */
+char *busyq_load_overlay(size_t *out_len);
+
+#endif /* BUSYQ_OVERLAY_H */


### PR DESCRIPTION
This pull request introduces support for detecting and executing bash scripts appended as overlay data to the ELF binary, with optional gzip compression. This feature is enabled via the new `BUSYQ_OVERLAY` build option and includes robust detection compatible with both regular and UPX-compressed binaries. Comprehensive tests are added to ensure correct behavior across all overlay scenarios.

**Overlay script support:**

* Added the `BUSYQ_OVERLAY` build option in `CMakeLists.txt` to enable detection and execution of bash scripts appended as ELF overlay data. When enabled, the build includes new source files and compile definitions for overlay support. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR29) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR157-R162)
* Introduced `src/overlay.c` and `src/overlay.h`, which implement overlay detection by parsing ELF headers to locate appended data, and auto-decompress gzip overlays using zlib. Provides the `busyq_load_overlay` function for use in the main binary. [[1]](diffhunk://#diff-201aa42349462d389007cdbbb0683bd1f6fbd67b3c7252d370efb8d338e9997dR1-R234) [[2]](diffhunk://#diff-f9e20d55489c2611567e41f642724ed576817dc17ed8a8b35ec9d2c61574627cR1-R41)
* Updated `src/main.c` to check for and execute overlay scripts after applet dispatch. Scripts are run via `bash -c`, forwarding all command-line arguments. This preserves existing applet behavior and ensures overlays run as expected. [[1]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176R8-R23) [[2]](diffhunk://#diff-e0cf5b28d9b6b600f0af2bc78e8fd30ec675fd731a5da86f0c4283ffc0e40176R51-R97)

**Testing and CI improvements:**

* Enhanced the `Dockerfile` to retain a pre-UPX binary for overlay tests, and added a matrix of overlay test cases covering stripped/UPX binaries and raw/gzip script overlays. Ensures overlay functionality works in all supported scenarios. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L61-R64) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R101) [[3]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R150-R167)
* Added overlay tests to the development container script (`scripts/dev-container.sh`), verifying both raw and gzip overlays in the dev environment.